### PR TITLE
Fixed linker problem with TDatabasePDG by changing how libEG is called

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ SET(INCL_FILES ${INCL_FILES} ${PHDRS})
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/etc/cmake)
 
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)
-find_package(ROOT "6.00" REQUIRED COMPONENTS RIO Net)
+find_package(ROOT "6.00" REQUIRED COMPONENTS RIO Net EG)
 if(ROOT_VERSION LESS 6.00)
 	message(FATAL_ERROR "The required ROOT version has to be at least 6.00, found " ${ROOT_VERSION})
 endif()
@@ -81,9 +81,6 @@ message(STATUS "Found ROOT version: " ${ROOT_VERSION})
 
 #---Define useful ROOT functions and macros (e.g. ROOT_GENERATE_DICTIONARY)
 include(${ROOT_USE_FILE})
-
-# explicitly tell the linker to use the EG library to resolve linker problems with TDatabasePDG::Instance()
-set(DEFAULT_LINKER_FLAGS "-lEG")
 
 ##LIST(APPEND INCL_FILES ${PHDRS})
 


### PR DESCRIPTION
Hi,

in the last days I had problem with compiling A2Geant4 with Pluto because of linking issues with this TDatabasePDG() that is contained in the libEG library.

I saw that in the CMakeList.txt file the problem was addressed by setting the flag "-lEG", nevertheless it did not seem to work anymore (at least for me and others). 

I guess that the correct way to include additional root libraries is now (??) different:
https://root.cern/manual/integrate_root_into_my_cmake_project

I updated the CMakeList.txt file accordingly to this, and everything seems to be working just fine. 